### PR TITLE
 #2972944 Admin routes not working when site is in a subfolder

### DIFF
--- a/domain_site_settings/domain_site_settings.routing.yml
+++ b/domain_site_settings/domain_site_settings.routing.yml
@@ -1,5 +1,5 @@
 domain_site_settings.list:
-  path: '/admin/config/domain/domain_site_settings'
+  path: 'admin/config/domain/domain_site_settings'
   defaults:
     _controller: '\Drupal\domain_site_settings\Controller\DomainSiteSettingsController::domainList'
     _title: 'Domains sites list'
@@ -8,7 +8,7 @@ domain_site_settings.list:
   options:
     _admin_route: TRUE
 domain_site_settings.config_form:
-  path: '/admin/config/domain/domain_site_settings/{domain_id}/edit'
+  path: 'admin/config/domain/domain_site_settings/{domain_id}/edit'
   defaults:
     _form: '\Drupal\domain_site_settings\Form\DomainConfigSettingsForm'
     _title: 'Domain site settings'

--- a/domain_site_settings/domain_site_settings.services.yml
+++ b/domain_site_settings/domain_site_settings.services.yml
@@ -1,6 +1,6 @@
 services:
   domain_site_settings.overrider:
     class: \Drupal\domain_site_settings\Configuration\DomainConfigOverride
-    arguments: ['@domain.negotiator', '@config.factory']
+    arguments: ['@config.factory']
     tags:
       - {name: config.factory.override, priority: 5}

--- a/domain_site_settings/src/Configuration/DomainConfigOverride.php
+++ b/domain_site_settings/src/Configuration/DomainConfigOverride.php
@@ -17,13 +17,6 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 class DomainConfigOverride implements ConfigFactoryOverrideInterface {
 
   /**
-   * The Domain negotiator.
-   *
-   * @var \Drupal\domain\DomainNegotiatorInterface
-   */
-  protected $negotiator;
-
-  /**
    * The config factory.
    *
    * @var \Drupal\Core\Config\ConfigFactoryInterface
@@ -34,15 +27,10 @@ class DomainConfigOverride implements ConfigFactoryOverrideInterface {
    * Constructs a DomainSourcePathProcessor object.
    *
    *   The domain loader.
-   * @param \Drupal\domain\DomainNegotiatorInterface $negotiator
-   *   The domain negotiator.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The module handler service.
    */
-  public function __construct(
-      DomainNegotiatorInterface $negotiator,
-      ConfigFactoryInterface $config_factory) {
-    $this->negotiator = $negotiator;
+  public function __construct(ConfigFactoryInterface $config_factory) {
     $this->configFactory = $config_factory;
   }
 
@@ -59,7 +47,8 @@ class DomainConfigOverride implements ConfigFactoryOverrideInterface {
   public function loadOverrides($names) {
     $overrides = array();
     if (in_array('system.site', $names)) {
-      $domain = $this->negotiator->getActiveDomain();
+      $negotiator = \Drupal::service('domain.negotiator');
+      $domain = $negotiator->getActiveDomain();
       if (!empty($domain)) {
         $domain_key = $domain->id();
         $configFactory = $this->configFactory->get('domain_site_settings.domainconfigsettings');


### PR DESCRIPTION
PATCH from "#2972944 Admin routes not working when site is installed in a subfolder": https://www.drupal.org/project/domain_site_settings/issues/2972944